### PR TITLE
Add measles case update workflow

### DIFF
--- a/.github/workflows/update_measles_cases.yml
+++ b/.github/workflows/update_measles_cases.yml
@@ -1,0 +1,39 @@
+name: Update measles cases
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: read
+
+jobs:
+  update-measles-cases:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/epiforesite/idcup:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Refresh measles cases data
+        run: make data/measles_cases.csv -B
+
+      - name: Commit updated data
+        run: |
+          if [ -z "$(git status --porcelain -- data/measles_cases.csv)" ]; then
+            echo "No changes detected in data/measles_cases.csv"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/measles_cases.csv
+          git commit -m "Update measles cases data"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .Rproj
 *.Rout
 *.csv
+!data/measles_cases.csv

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ MEASLES_TREE ?= gvegayon/fast-mixing
 help:
 	@echo "Available targets:"
 	@echo "  data/census_age.csv    Generates the census_age.csv file from the data/census_age.R script"
+	@echo "  data/measles_cases.csv Generates the measles_cases.csv file from the data/measles_cases.R script"
 	@echo "  data/mixing_matrix.rds Generates the mixing_matrix.rds file from the data/mixing_matrix.R script"
 	@echo "  update-measles         Updates to the latest version from the UofUEpiBio/measles repository"
 	@echo "  scenario               Generates a scenario markdown file for a specified city (default: Miami)"
@@ -12,6 +13,9 @@ help:
 
 data/census_age.csv: data/census_age.R 
 	Rscript --verbose data/census_age.R
+
+data/measles_cases.csv: data/measles_cases.R
+	Rscript --verbose data/measles_cases.R
 
 data/mixing_matrix.rds: data/mixing_matrix.R data/census_age.csv
 	Rscript --verbose data/mixing_matrix.R

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # idcup
 
-[![Render reports](https://github.com/EpiForeSITE/idcup/actions/workflows/render_reports.yml/badge.svg)](https://github.com/EpiForeSITE/idcup/actions/workflows/render_reports.yml)
+[![Render reports](https://github.com/EpiForeSITE/idcup/actions/workflows/render_reports.yml/badge.svg)](https://github.com/EpiForeSITE/idcup/actions/workflows/render_reports.yml) [![Fetch measles cases](https://github.com/EpiForeSITE/idcup/actions/workflows/update_measles_cases.yml/badge.svg)](https://github.com/EpiForeSITE/idcup/actions/workflows/update_measles_cases.yml)
 
 Agent-based measles outbreak simulations across major U.S. cities, built on [epiworldR](https://github.com/UofUEpiBio/epiworldR) and the [measles](https://github.com/UofUEpiBio/measles) R package. Scenarios are parameterized Quarto documents that can be rendered per city using census-derived age structure and MMR vaccination coverage.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Los Angeles, San Francisco, New York City, Boston, Houston, Dallas, Philadelphia
 data/
   census_age.csv       Age-structured population counts by city (generated)
   census_age.R         Script to pull county-level census data via multigroup.vaccine
+  measles_cases.csv    County-level measles case updates mapped to project cities (generated)
+  measles_cases.R      Script to pull measles case updates for project cities
   population.csv       Total city populations (source: census.gov)
   mmr.csv              MMR vaccination estimates by city (source: CDC MMWR 2023-24)
 scenarios/
@@ -70,6 +72,7 @@ quarto render scenarios/template.qmd -P city:"Miami"
 |------|--------|
 | `population.csv` | U.S. Census Bureau |
 | `census_age.csv` | U.S. Census Bureau (2024, county-level, via `multigroup.vaccine`) |
+| `measles_cases.csv` | [CSSEGISandData/measles_data](https://github.com/CSSEGISandData/measles_data) county-level update feed |
 | `mmr.csv` | [CDC MMWR 2023–24 kindergarten vaccination coverage](https://www.cdc.gov/mmwr/volumes/73/wr/mm7341a3.htm) |
 
 Relevant age groups: are 0to4, 5to9, 10to14, 15to19, 20to24, 25to29, 30to34, 35to39, 40to44, 45to49, 50to54, 55to59, 60to64, 65to69, 70to74, 75to79, 80to84, 85plus.

--- a/data/measles_cases.R
+++ b/data/measles_cases.R
@@ -1,0 +1,89 @@
+library(data.table)
+
+source_url <- "https://raw.githubusercontent.com/CSSEGISandData/measles_data/refs/heads/main/measles_county_all_updates_detailed.csv"
+output_path <- file.path("data", "measles_cases.csv")
+
+# City-to-county mapping aligned with data/census_age.R so we use the same
+# geographic units across the project. Filtering on county FIPS avoids pulling
+# state-level rows or similarly named counties from the wrong state.
+city_lookup <- data.table(
+  city = c(
+    "Los Angeles", "San Francisco", "New York City", "Boston",
+    "Houston", "Dallas", "Philadelphia", "Atlanta",
+    "Seattle", "Miami", "Kansas City"
+  ),
+  state = c(
+    "California", "California", "New York", "Massachusetts",
+    "Texas", "Texas", "Pennsylvania", "Georgia",
+    "Washington", "Florida", "Missouri"
+  ),
+  county = c(
+    "Los Angeles", "San Francisco", "New York", "Suffolk",
+    "Harris", "Dallas", "Philadelphia", "Fulton",
+    "King", "Miami-Dade", "Jackson"
+  ),
+  location_id = c(
+    6037L, 6075L, 36061L, 25025L,
+    48201L, 48113L, 42101L, 13121L,
+    53033L, 12086L, 29095L
+  )
+)
+
+cases <- fread(source_url)
+
+required_columns <- c(
+  "location_name",
+  "location_id",
+  "location_type",
+  "date",
+  "outcome_type",
+  "value"
+)
+
+missing_columns <- setdiff(required_columns, names(cases))
+if (length(missing_columns) > 0) {
+  stop(
+    sprintf(
+      "The measles source is missing expected column(s): %s",
+      paste(missing_columns, collapse = ", ")
+    ),
+    call. = FALSE
+  )
+}
+
+cases <- cases[
+  location_type == "county" &
+  location_id %in% city_lookup$location_id
+]
+
+cases <- merge(
+  cases,
+  city_lookup,
+  by = "location_id",
+  all.x = TRUE,
+  sort = FALSE
+)
+
+if (cases[, any(is.na(city))]) {
+  stop("Some filtered measles rows could not be mapped back to a project city.", call. = FALSE)
+}
+
+setcolorder(
+  cases,
+  c(
+    "city",
+    "state",
+    "county",
+    "location_name",
+    "location_id",
+    "location_type",
+    "date",
+    "outcome_type",
+    "value"
+  )
+)
+
+setorder(cases, city, date, outcome_type)
+fwrite(cases, output_path)
+
+message(sprintf("Wrote %d rows to %s", nrow(cases), output_path))

--- a/data/measles_cases.csv
+++ b/data/measles_cases.csv
@@ -1,0 +1,121 @@
+city,state,county,location_name,location_id,location_type,date,outcome_type,value
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-01-28,case_imported,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-01-28,case_lab-confirmed,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-01-28,case_unvaccinated,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-03-31,case_lab-confirmed,2
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-03-31,case_local,2
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-03-31,case_unvaccinated,2
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-05-19,case_imported,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-05-19,case_lab-confirmed,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-05-19,case_unvaccinated,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-06-06,case_lab-confirmed,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-06-06,case_local,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-06-06,case_unvaccinated,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-06-18,case_lab-confirmed,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-06-18,case_local,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-06-18,case_unvaccinated,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-09-12,case_lab-confirmed,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-09-12,case_local,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-09-12,case_unvaccinated,1
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-09-23,case_lab-confirmed,3
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-09-23,case_local,3
+Atlanta,Georgia,Fulton,"Fulton, Georgia",13121,county,2025-09-23,case_unvaccinated,2
+Boston,Massachusetts,Suffolk,"Greater Boston, Massachusetts",25025,county,2026-02-27,case_imported,1
+Boston,Massachusetts,Suffolk,"Greater Boston, Massachusetts",25025,county,2026-02-27,case_lab-confirmed,1
+Dallas,Texas,Dallas,"Dallas, Texas",48113,county,2025-06-24,case_lab-confirmed,1
+Dallas,Texas,Dallas,"Dallas, Texas",48113,county,2025-06-24,case_local,1
+Houston,Texas,Harris,"Harris, Texas",48201,county,2025-01-23,case_imported,2
+Houston,Texas,Harris,"Harris, Texas",48201,county,2025-01-23,case_lab-confirmed,2
+Houston,Texas,Harris,"Harris, Texas",48201,county,2025-03-20,case_lab-confirmed,1
+Houston,Texas,Harris,"Harris, Texas",48201,county,2025-03-20,case_local,3
+Houston,Texas,Harris,"Harris, Texas",48201,county,2025-07-15,case_lab-confirmed,1
+Houston,Texas,Harris,"Harris, Texas",48201,county,2025-07-15,case_local,1
+Houston,Texas,Harris,"Harris, Texas",48201,county,2025-08-07,case_lab-confirmed,1
+Houston,Texas,Harris,"Harris, Texas",48201,county,2025-08-07,case_local,1
+Houston,Texas,Harris,"Harris, Texas",48201,county,2026-04-15,case_lab-confirmed,4
+Houston,Texas,Harris,"Harris, Texas",48201,county,2026-04-15,case_local,4
+Kansas City,Missouri,Jackson,"Jackson, Missouri",29095,county,2026-03-03,case_lab-confirmed,1
+Kansas City,Missouri,Jackson,"Jackson, Missouri",29095,county,2026-03-03,case_local,1
+Kansas City,Missouri,Jackson,"Jackson, Missouri",29095,county,2026-03-03,case_unvaccinated,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-03-11,case_imported,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-03-11,case_lab-confirmed,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-04-25,case_imported,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-04-25,case_lab-confirmed,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-05-07,case_imported,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-05-07,case_lab-confirmed,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-06-06,case_imported,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-06-06,case_lab-confirmed,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-06-12,case_imported,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2025-06-12,case_lab-confirmed,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2026-01-30,case_imported,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2026-01-30,case_lab-confirmed,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2026-01-31,case_imported,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2026-01-31,case_lab-confirmed,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2026-02-02,case_imported,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2026-02-02,case_lab-confirmed,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2026-02-19,case_imported,1
+Los Angeles,California,Los Angeles,"Los Angeles, California",6037,county,2026-02-19,case_lab-confirmed,1
+Miami,Florida,Miami-Dade,"Miami-Dade, Florida",12086,county,2025-03-06,case_lab-confirmed,1
+Miami,Florida,Miami-Dade,"Miami-Dade, Florida",12086,county,2025-03-06,case_local,1
+Miami,Florida,Miami-Dade,"Miami-Dade, Florida",12086,county,2026-01-27,case_lab-confirmed,1
+Miami,Florida,Miami-Dade,"Miami-Dade, Florida",12086,county,2026-01-27,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-01-31,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-01-31,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-01-31,case_unvaccinated,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-02-26,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-02-26,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-02-26,case_unvaccinated,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-03-20,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-03-20,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-05-16,case_lab-confirmed,3
+New York City,New York,New York,"New York City, New York",36061,county,2025-05-16,case_local,3
+New York City,New York,New York,"New York City, New York",36061,county,2025-07-11,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-07-11,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-08-01,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-08-01,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-08-18,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-08-18,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-09-08,case_lab-confirmed,3
+New York City,New York,New York,"New York City, New York",36061,county,2025-09-08,case_local,3
+New York City,New York,New York,"New York City, New York",36061,county,2025-09-12,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-09-12,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-09-19,case_lab-confirmed,2
+New York City,New York,New York,"New York City, New York",36061,county,2025-09-19,case_local,2
+New York City,New York,New York,"New York City, New York",36061,county,2025-09-26,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-09-26,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-10-17,case_lab-confirmed,2
+New York City,New York,New York,"New York City, New York",36061,county,2025-10-17,case_local,2
+New York City,New York,New York,"New York City, New York",36061,county,2025-11-28,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-11-28,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-12-05,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2025-12-05,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2026-02-13,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2026-02-13,case_local,1
+New York City,New York,New York,"New York City, New York",36061,county,2026-03-12,case_lab-confirmed,2
+New York City,New York,New York,"New York City, New York",36061,county,2026-03-12,case_local,2
+New York City,New York,New York,"New York City, New York",36061,county,2026-03-27,case_lab-confirmed,1
+New York City,New York,New York,"New York City, New York",36061,county,2026-03-27,case_local,1
+Philadelphia,Pennsylvania,Philadelphia,"Philadelphia, Pennsylvania",42101,county,2025-03-31,case_imported,1
+Philadelphia,Pennsylvania,Philadelphia,"Philadelphia, Pennsylvania",42101,county,2025-03-31,case_lab-confirmed,1
+Philadelphia,Pennsylvania,Philadelphia,"Philadelphia, Pennsylvania",42101,county,2025-04-11,case_imported,1
+Philadelphia,Pennsylvania,Philadelphia,"Philadelphia, Pennsylvania",42101,county,2025-04-11,case_lab-confirmed,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-02-27,case_imported,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-02-27,case_lab-confirmed,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-04-11,case_imported,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-04-11,case_lab-confirmed,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-04-24,case_imported,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-04-24,case_lab-confirmed,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-04-24,case_unvaccinated,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-05-20,case_imported,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-05-20,case_lab-confirmed,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-06-24,case_imported,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-06-24,case_lab-confirmed,2
+Seattle,Washington,King,"King, Washington",53033,county,2025-06-24,case_local,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-06-24,case_vaccinated,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-10-28,case_imported,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-10-28,case_lab-confirmed,1
+Seattle,Washington,King,"King, Washington",53033,county,2025-10-28,case_vaccinated,1
+Seattle,Washington,King,"King, Washington",53033,county,2026-04-01,case_lab-confirmed,2
+Seattle,Washington,King,"King, Washington",53033,county,2026-04-01,case_local,2
+Seattle,Washington,King,"King, Washington",53033,county,2026-04-10,case_lab-confirmed,1
+Seattle,Washington,King,"King, Washington",53033,county,2026-04-10,case_local,1


### PR DESCRIPTION
## Summary
- Add `data/measles_cases.R` to pull the county-level CSSE measles feed, filter it to the project cities by county FIPS, and write `data/measles_cases.csv`.
- Add a GitHub Action that regenerates the CSV in the same container image used for report rendering and commits changes with `github-actions[bot]` when the file changes.
- Update the Makefile, README, and `.gitignore` so the generated CSV is tracked and documented.

## Testing
- Validated the new R script parses successfully.
- Ran `make data/measles_cases.csv -B` locally to regenerate the CSV and confirm the output file is produced.